### PR TITLE
Apply GoSafeGetgPass on RISC-V

### DIFF
--- a/driver/CompileGo.cpp
+++ b/driver/CompileGo.cpp
@@ -901,9 +901,10 @@ bool CompileGoImpl::invokeBackEnd(const Action &jobAction)
       createTargetTransformInfoWrapperPass(target_->getTargetIRAnalysis()));
   createPasses(modulePasses, functionPasses);
 
-  // Disable inlining getg in some cases on x86_64.
-  if (triple_.getArch() == llvm::Triple::x86_64) {
-      modulePasses.add(createGoSafeGetgPass());
+  // Disable inlining getg in some cases on x86_64 and RISC-V.
+  if (triple_.getArch() == llvm::Triple::x86_64 ||
+      triple_.getArch() == llvm::Triple::riscv64) {
+    modulePasses.add(createGoSafeGetgPass());
   }
 
   // Add statepoint insertion pass to the end of optimization pipeline,


### PR DESCRIPTION
Fixes check_libgo_runtime and many spurious check errors (to be confirmed).