### PR TITLE
Gollvm build riscv

### DIFF
--- a/cmake/modules/LibffiUtils.cmake
+++ b/cmake/modules/LibffiUtils.cmake
@@ -90,6 +90,10 @@ function(setup_libffi libffi_srcroot)
   if(GOLLVM_USE_SPLIT_STACK)
     string(APPEND libffiflags " -fsplit-stack ${CFPROTECTION_WORKAROUND}")
   endif()
+  # Force -funwind-tables to be used for RISC-V so .eh_frame exists for stack unwinding.
+  if (${goarch} STREQUAL "riscv64")
+    string(APPEND libffiflags " -funwind-tables")
+  endif()
   string(APPEND libffiflags " ${GOLLVM_EXTRA_CFLAGS}")
 
   # Copy correct version of ffitarget.h to libgo binary root.

--- a/driver/CompileGo.cpp
+++ b/driver/CompileGo.cpp
@@ -901,9 +901,10 @@ bool CompileGoImpl::invokeBackEnd(const Action &jobAction)
       createTargetTransformInfoWrapperPass(target_->getTargetIRAnalysis()));
   createPasses(modulePasses, functionPasses);
 
-  // Disable inlining getg in some cases on x86_64.
-  if (triple_.getArch() == llvm::Triple::x86_64) {
-      modulePasses.add(createGoSafeGetgPass());
+  // Disable inlining getg in some cases on x86_64 and RISC-V.
+  if (triple_.getArch() == llvm::Triple::x86_64 ||
+      triple_.getArch() == llvm::Triple::riscv64) {
+    modulePasses.add(createGoSafeGetgPass());
   }
 
   // Add statepoint insertion pass to the end of optimization pipeline,


### PR DESCRIPTION
Fixes "failed to throw unwind exception (reason=5)" error which involves 4 tests.