### PR TITLE
gollvm: pass arch info to the integrated assembler

### DIFF
--- a/driver/ArchCpuSetup.cpp
+++ b/driver/ArchCpuSetup.cpp
@@ -1,0 +1,71 @@
+//===-- ArchCpuSetup.cpp --------------------------------------------------===//
+//
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//===----------------------------------------------------------------------===//
+//
+// Gollvm driver helper function setupArchCpu
+//
+//===----------------------------------------------------------------------===//
+
+#include "ArchCpuSetup.h"
+
+#include "llvm/Option/Arg.h"
+#include "llvm/Support/Host.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace gollvm { namespace arch {
+#include "ArchCpusAttrs.h"
+} }
+
+using namespace llvm;
+
+bool gollvm::driver::setupArchCpu(opt::Arg *cpuarg, std::string &cpu,
+                               std::string &attrs, Triple triple,
+                               const char *progname) {
+  std::string cpuStr;
+  if (cpuarg != nullptr) {
+    std::string val(cpuarg->getValue());
+    if (val == "native")
+      cpuStr = sys::getHostCPUName().str();
+    else
+      cpuStr = cpuarg->getValue();
+  }
+
+  // Locate correct entry in architectures table for this triple
+  const gollvm::arch::CpuAttrs *cpuAttrs = nullptr;
+  for (unsigned i = 0; gollvm::arch::triples[i].cpuattrs != nullptr; i += 1) {
+    if (!strcmp(triple.str().c_str(), gollvm::arch::triples[i].triple)) {
+      cpuAttrs = gollvm::arch::triples[i].cpuattrs;
+      break;
+    }
+  }
+  if (cpuAttrs == nullptr) {
+    errs() << progname << ": unable to determine target CPU features for "
+           << "target " << triple.str() << "\n";
+    return false;
+  }
+
+  // If no CPU specified, use first entry. Otherwise look for CPU name.
+  if (!cpuStr.empty()) {
+    bool found = false;
+    while (strlen(cpuAttrs->cpu) != 0) {
+      if (!strcmp(cpuAttrs->cpu, cpuStr.c_str())) {
+        // found
+        found = true;
+        break;
+      }
+      cpuAttrs++;
+    }
+    if (!found) {
+      errs() << progname << ": invalid setting for -march:"
+             << " -- unable to identify CPU '" << cpuStr << "'\n";
+      return false;
+    }
+  }
+  cpu = cpuAttrs->cpu;
+  attrs = cpuAttrs->attrs;
+  return true;
+}

--- a/driver/ArchCpuSetup.h
+++ b/driver/ArchCpuSetup.h
@@ -1,0 +1,27 @@
+//===-- ArchCpuSetup.cpp --------------------------------------------------===//
+//
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares gollvm driver helper function setupArchCpu.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef GOLLVM_DRIVER_ARCHCPUSETUP_H
+#define GOLLVM_DRIVER_ARCHCPUSETUP_H
+
+#include "Tool.h"
+
+namespace gollvm {
+namespace driver {
+
+bool setupArchCpu(llvm::opt::Arg *cpuarg, std::string &cpu, std::string &attrs,
+               llvm::Triple triple_, const char *progname_);
+
+} // end namespace driver
+} // end namespace gollvm
+
+#endif

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(${EXTINSTALLDIR}/include)
 # A library containing driver utility code.
 add_llvm_library(LLVMDriverUtils
   Action.cpp
+  ArchCpuSetup.cpp
   Artifact.cpp
   Command.cpp
   Compilation.cpp

--- a/driver/CompileGo.cpp
+++ b/driver/CompileGo.cpp
@@ -22,6 +22,7 @@
 #include "GollvmPasses.h"
 
 #include "Action.h"
+#include "ArchCpuSetup.h"
 #include "Artifact.h"
 #include "Driver.h"
 #include "ToolChain.h"
@@ -470,7 +471,7 @@ bool CompileGoImpl::setup(const Action &jobAction)
 
   // Support -march
   opt::Arg *cpuarg = args_.getLastArg(gollvm::options::OPT_march_EQ);
-  if (!setupArch(cpuarg, targetCpuAttr_, targetFeaturesAttr_, triple_, progname_))
+  if (!setupArchCpu(cpuarg, targetCpuAttr_, targetFeaturesAttr_, triple_, progname_))
     return false;
 
   // Create target machine
@@ -482,53 +483,6 @@ bool CompileGoImpl::setup(const Action &jobAction)
                                      CM, cgolvl_));
   assert(target_.get() && "Could not allocate target machine!");
 
-  return true;
-}
-
-bool setupArch(opt::Arg *cpuarg, std::string &cpu, std::string &attrs,
-               Triple triple_, const char *progname_) {
-  std::string cpuStr;
-  if (cpuarg != nullptr) {
-    std::string val(cpuarg->getValue());
-    if (val == "native")
-      cpuStr = sys::getHostCPUName().str();
-    else
-      cpuStr = cpuarg->getValue();
-  }
-
-  // Locate correct entry in architectures table for this triple
-  const gollvm::arch::CpuAttrs *cpuAttrs = nullptr;
-  for (unsigned i = 0; gollvm::arch::triples[i].cpuattrs != nullptr; i += 1) {
-    if (!strcmp(triple_.str().c_str(), gollvm::arch::triples[i].triple)) {
-      cpuAttrs = gollvm::arch::triples[i].cpuattrs;
-      break;
-    }
-  }
-  if (cpuAttrs == nullptr) {
-    errs() << progname_ << ": unable to determine target CPU features for "
-           << "target " << triple_.str() << "\n";
-    return false;
-  }
-
-  // If no CPU specified, use first entry. Otherwise look for CPU name.
-  if (!cpuStr.empty()) {
-    bool found = false;
-    while (strlen(cpuAttrs->cpu) != 0) {
-      if (!strcmp(cpuAttrs->cpu, cpuStr.c_str())) {
-        // found
-        found = true;
-        break;
-      }
-      cpuAttrs++;
-    }
-    if (!found) {
-      errs() << progname_ << ": invalid setting for -march:"
-             << " -- unable to identify CPU '" << cpuStr << "'\n";
-      return false;
-    }
-  }
-  cpu = cpuAttrs->cpu;
-  attrs = cpuAttrs->attrs;
   return true;
 }
 

--- a/driver/IntegAssembler.cpp
+++ b/driver/IntegAssembler.cpp
@@ -23,6 +23,7 @@
 #include "CompileGo.h"
 
 #include "Action.h"
+#include "ArchCpuSetup.h"
 #include "Artifact.h"
 #include "Driver.h"
 #include "ToolChain.h"
@@ -202,7 +203,7 @@ bool IntegAssemblerImpl::invokeAssembler()
   std::string FS;
   std::string CPU;
   opt::Arg *cpuarg = args_.getLastArg(gollvm::options::OPT_march_EQ);
-  setupArch(cpuarg, CPU, FS, triple_, progname_);
+  setupArchCpu(cpuarg, CPU, FS, triple_, progname_);
   std::unique_ptr<MCStreamer> Str;
   std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(


### PR DESCRIPTION
https://go-review.googlesource.com/c/gollvm/+/425854

Currently, architecture information is passed to the compiler but not
the integrated assembler, causing discrepancies in the ABI chosen by
the two tools, especially on the RISC-V platform.

This patch makes sure both share the same architecture information.

Change-Id: I29f441e86e06f1f0b46c3ea62576a7d1291c2ce4