### PR TITLE
Better cross-compilation

### DIFF
--- a/cmake/modules/GoPackage.cmake
+++ b/cmake/modules/GoPackage.cmake
@@ -82,7 +82,9 @@ function(add_go_package pkgpath dest)
   # Command to build *.gox.tmp
   set(objcopycommand "objcopy")
   if (GOLLVM_DRIVER_DIR)
-    set(objcopycommand "${LLVM_DEFAULT_TARGET_TRIPLE}-objcopy")
+    # Assume objcopy and the compiler driver are placed in the same directory
+    get_filename_component(c_compiler_dir ${CMAKE_C_COMPILER} DIRECTORY)
+    set(objcopycommand ${c_compiler_dir}/${LLVM_DEFAULT_TARGET_TRIPLE}-objcopy)
   endif()
 
   add_custom_command(

--- a/driver/LinuxToolChain.cpp
+++ b/driver/LinuxToolChain.cpp
@@ -144,10 +144,6 @@ std::string Linux::getDynamicLinker(const llvm::opt::ArgList &args)
       Loader = "ld-linux-riscv64-lp64d.so.1";
       break;
   }
-  if (auto *Arg = args.getLastArg(gollvm::options::OPT_sysroot_EQ)) {
-    std::string Sysroot = Arg->getValue();
-    return Sysroot + "/" + LibDir + "/" + Loader;
-  }
   return "/" + LibDir + "/" + Loader;
 }
 


### PR DESCRIPTION
https://go-review.googlesource.com/c/gollvm/+/425556

1. Allow objcopy to reside outside of PATH;
2. Avoid setting the dynamic linker based on local sysroot

Change-Id: Ia3010d2e8fb3dc48ddf2811dfe2b5f0901d94bad