### PR TITLE
fix wrongly generate defaultGCCGO when specifying GOLLVM_DRIVER_DIR

### DIFF
--- a/cmake/modules/AutoGenGo.cmake
+++ b/cmake/modules/AutoGenGo.cmake
@@ -375,11 +375,8 @@ function(mkzdefaultcc package outfile ccpath cxxpath)
   CMAKE_PARSE_ARGUMENTS(ARG "EXPORT" "" "" ${ARGN})
 
   # Construct default driver path
-  if (GOLLVM_DRIVER_DIR)
-    set(driverpath "${GOLLVM_DRIVER_DIR}/bin/llvm-goc")
-  else()
-    set(driverpath "${GOLLVM_INSTALL_DIR}/bin/llvm-goc")
-  endif()
+  set(driverpath "${GOLLVM_INSTALL_DIR}/bin/llvm-goc")
+
 
   file(REMOVE ${outfile})
   file(WRITE ${outfile} "package ${package}\n\n")


### PR DESCRIPTION
Change-Id: If6a3bf1662c98de6aa52175dd0b52eb8d8333970